### PR TITLE
refactor: use a single axios instance for WordPress

### DIFF
--- a/src/axios-wordpress.js
+++ b/src/axios-wordpress.js
@@ -1,0 +1,8 @@
+import axios from 'axios'
+const { REACT_APP_WORDPRESS_URL } = process.env
+
+const instance = axios.create({
+  baseURL: `${REACT_APP_WORDPRESS_URL}/wp-json/wp/v2/`,
+})
+
+export default instance

--- a/src/containers/Blog/Post/Post.js
+++ b/src/containers/Blog/Post/Post.js
@@ -4,7 +4,7 @@ import Icon from '@mdi/react'
 import { mdiArrowLeft } from '@mdi/js'
 import Parallax from '../../../components/Parallax/Parallax'
 import Container from '../../../components/Container/Container'
-import axios from 'axios'
+import wp from '../../../axios-wordpress'
 import PropTypes from 'prop-types'
 
 class Post extends Component {
@@ -13,14 +13,7 @@ class Post extends Component {
   }
 
   componentDidMount() {
-    const { REACT_APP_WORDPRESS_URL } = process.env
-
-    axios
-      .get(
-        `${REACT_APP_WORDPRESS_URL}/wp-json/wp/v2/posts?_embed&slug=${
-          this.props.match.params.postSlug
-        }`
-      )
+    wp.get(`posts?_embed&slug=${this.props.match.params.postSlug}`)
       .then(res => {
         this.setState({
           post: res.data[0],

--- a/src/containers/Home/Posts/Posts.js
+++ b/src/containers/Home/Posts/Posts.js
@@ -13,7 +13,7 @@ import {
   mdiShareVariant,
 } from '@mdi/js'
 import idgen from '../../../idgen'
-import axios from 'axios'
+import wp from '../../../axios-wordpress'
 
 class Posts extends Component {
   state = {
@@ -21,12 +21,7 @@ class Posts extends Component {
   }
 
   componentDidMount() {
-    const { REACT_APP_WORDPRESS_URL } = process.env
-
-    axios
-      .get(
-        `${REACT_APP_WORDPRESS_URL}/wp-json/wp/v2/posts?_embed&order=desc&order_by=date&per_page=3`
-      )
+    wp.get('posts?_embed&order=desc&order_by=date&per_page=3')
       .then(response => {
         this.renderPosts(response.data)
       })


### PR DESCRIPTION
Now both `Post` and `Posts` component uses this single `axios` instance

Closes #30