### PR TITLE
fix: remove Google Fonts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,6 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <link rel="stylesheet" href="%PUBLIC_URL%/materialize.css" />
-    <link href="https://fonts.googleapis.com/css?family=Raleway|Roboto:300,400" rel="stylesheet" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
This is now handled by PostCSS plugin Font Magician.
For more information, please see #8

Closes #47